### PR TITLE
[DO NOT MERGE] Hyperblitz Mode 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ Functions to run alternate game modes are under their corresponding namespaces.
     - Regen on and start kitted up. Quick border close in.
     - Meant to mimic UHC endgames but a bit more forgiving.
     - Games complete in 50 mins or less.
+- **Hyper Blitz**
+	- Game gives enhanced tools to encourage nether trip and riskier actions
+	- Players drop diamonds along with Golden apples
+	- Players start with lapis, flint & steel, a bow, and nether wart

--- a/uhcdp/data/hyper_blitz/functions/kitup.mcfunction
+++ b/uhcdp/data/hyper_blitz/functions/kitup.mcfunction
@@ -1,0 +1,18 @@
+item entity @a armor.head replace minecraft:iron_helmet 1
+item entity @a armor.chest replace minecraft:iron_chestplate 1
+item entity @a armor.legs replace minecraft:iron_leggings 1
+item entity @a armor.feet replace minecraft:iron_boots 1
+item entity @a weapon.offhand replace minecraft:shield 1
+give @a minecraft:diamond_pickaxe 1
+give @a minecraft:iron_sword 1
+give @a minecraft:iron_axe 1
+give @a minecraft:bow 1
+give @a minecraft:golden_apple 1
+give @a minecraft:lava_bucket 1
+give @a minecraft:water_bucket 1
+give @a minecraft:cobblestone 32
+give @a minecraft:oak_planks 64
+give @a minecraft:lapis_lazuli 8
+give @a minecraft:nether_wart 1
+give @a minecraft:arrow 8
+give @a minecraft:flint_and_steel 1

--- a/uhcdp/data/hyper_blitz/functions/start.mcfunction
+++ b/uhcdp/data/hyper_blitz/functions/start.mcfunction
@@ -1,0 +1,34 @@
+# Misc
+fill 150 245 150 170 255 170 minecraft:air
+gamerule doDaylightCycle true
+gamerule naturalRegeneration false
+advancement revoke @a everything
+time set 0
+
+xp set @a 5 levels
+xp set @a 0 points
+
+#set end portal
+schedule function hyper_blitz:summon_endportal 3s append
+
+# Countdown (go also starts 1st day and enables daynight cycle)
+title @a actionbar {"text":"Speed UHC","color":"white"}
+function text:three
+schedule function text:two 1s replace
+schedule function text:one 2s append
+schedule function text:hyper_blitz 3s append 
+
+#starting kit
+schedule function hyper_blitz:kitup 3s append
+
+# Start timers for border and clear effects
+schedule function helpers:cleareffects 3s append
+
+#shrink border across 45 mins
+worldborder set 101 3000
+advancement grant @a[gamemode=survival] only uhc:walls_closing
+
+# Add kills and deaths scoreboard
+scoreboard objectives add kills playerKillCount "Kills"
+scoreboard objectives setdisplay sidebar kills
+scoreboard objectives add deaths deathCount "Deaths"

--- a/uhcdp/data/hyper_blitz/functions/stop.mcfunction
+++ b/uhcdp/data/hyper_blitz/functions/stop.mcfunction
@@ -1,0 +1,3 @@
+gamerule doDaylightCycle false
+worldborder set 1000
+gamemode spectator @a

--- a/uhcdp/data/hyper_blitz/functions/summon_endportal.mcfunction
+++ b/uhcdp/data/hyper_blitz/functions/summon_endportal.mcfunction
@@ -1,0 +1,12 @@
+/setblock 1 85 -2 minecraft:end_portal_frame[eye=true] replace
+/setblock 0 85 -2 minecraft:end_portal_frame[eye=false] replace
+/setblock -1 85 -2 minecraft:end_portal_frame[eye=true] replace
+/setblock 1 85 2 minecraft:end_portal_frame[eye=true] replace
+/setblock 0 85 2 minecraft:end_portal_frame[eye=false] replace
+/setblock -1 85 2 minecraft:end_portal_frame[eye=true] replace
+/setblock 2 85 1 minecraft:end_portal_frame[eye=true] replace
+/setblock 2 85 0 minecraft:end_portal_frame[eye=false] replace
+/setblock 2 85 -1 minecraft:end_portal_frame[eye=true] replace
+/setblock -2 85 1 minecraft:end_portal_frame[eye=true] replace
+/setblock -2 85 0 minecraft:end_portal_frame[eye=false] replace
+/setblock -2 85 -1 minecraft:end_portal_frame[eye=true] replace

--- a/uhcdp/data/minecraft/loot_tables/entities/player.json
+++ b/uhcdp/data/minecraft/loot_tables/entities/player.json
@@ -14,6 +14,20 @@
 					]
 				}
 			]
+		},
+		{
+			"rolls": 2,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "minecraft:diamond",
+					"conditions": [
+						{
+							"condition": "killed_by_player"
+						}
+					]
+				}
+			]
 		}
 	]
 }

--- a/uhcdp/data/text/functions/hyper_blitz.mcfunction
+++ b/uhcdp/data/text/functions/hyper_blitz.mcfunction
@@ -1,0 +1,6 @@
+title @a title {"text":"HYPER BLITZ!","color":"white"}
+playsound minecraft:entity.arrow.hit_player master @a 0 0 64 1000 0.67
+playsound minecraft:entity.wither.spawn ambient @a 0 0 64 1000
+particle minecraft:soul ~ ~ ~ 2 4 2 0 500 force
+time set 0
+gamerule doDaylightCycle true


### PR DESCRIPTION
Added a new hyperblitz mode to experiment with. This mode introduces a couple of Ideas I had to spice up UHC in regards to the nether and the end. Do not merge this branch as it does create changes in the looting table that everyone relies on.

- Gives players new items (Bow, Flint and Steel, 3 more arrows, 1 netherwart, and 10 lapis)
- Players drop two diamonds along with their golden apple.
- An enderportal will spawn at 0 85 0 with 4 missing eyes of ender
- If a team is able to kill the dragon they instantly win.

I think netherwart is much harder to find these days due to certain changes in nether generation and I want to make potions simi viable again. This may completely sway the balance of the game, but I thought it would be a fun experiment. Also the ender portal is an old minecrack addition since we have the borders so small. I think I want to add a tracking compass to this mode, but that requires reading more documentation on existing data packs to add it in. Open to thoughts and criticism.